### PR TITLE
Update ConfigurationExtensions.cs

### DIFF
--- a/ConfigurationExtensions.cs
+++ b/ConfigurationExtensions.cs
@@ -23,21 +23,21 @@ namespace Hangfire.Heartbeat
 
             DashboardRoutes.Routes.Add(
                 "/heartbeat/jsknockout",
-                new ContentDispatcher("application/js", "Hangfire.Heartbeat.Dashboard.js.knockout-3.4.2.js",
+                new ContentDispatcher("application/javascript", "Hangfire.Heartbeat.Dashboard.js.knockout-3.4.2.js",
                     TimeSpan.FromDays(30)));
 
             DashboardRoutes.Routes.Add(
                 "/heartbeat/jsknockoutorderable",
-                new ContentDispatcher("application/js", "Hangfire.Heartbeat.Dashboard.js.knockout.bindings.orderable.js",
+                new ContentDispatcher("application/javascript", "Hangfire.Heartbeat.Dashboard.js.knockout.bindings.orderable.js",
                     TimeSpan.FromDays(30)));
 
             DashboardRoutes.Routes.Add(
                 "/heartbeat/jsnumeral",
-                new ContentDispatcher("application/js", "Hangfire.Heartbeat.Dashboard.js.numeral.min.js", TimeSpan.FromDays(30)));
+                new ContentDispatcher("application/javascript", "Hangfire.Heartbeat.Dashboard.js.numeral.min.js", TimeSpan.FromDays(30)));
 
             DashboardRoutes.Routes.Add(
                 "/heartbeat/jspage",
-                new ContentDispatcher("application/js", "Hangfire.Heartbeat.Dashboard.js.OverviewPage.js", TimeSpan.FromSeconds(1)));
+                new ContentDispatcher("application/javascript", "Hangfire.Heartbeat.Dashboard.js.OverviewPage.js", TimeSpan.FromSeconds(1)));
 
             DashboardRoutes.Routes.Add(
                 "/heartbeat/cssstyles",


### PR DESCRIPTION
Update javascript virtual files' MIME type according to [RFC 4329](http://www.rfc-editor.org/rfc/rfc4329.txt).

This will avoid getting errors like
```
Refused to execute script from '/hangfire/heartbeat/jsknockout' because its MIME type ('application/js') is not executable, and strict MIME type checking is enabled.
```
and rendering the page unusable.