### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![dashboard](content/dashboard.png)
 
-A simple server monitoring plugin for Hangfire.
+Hangfire.Heartbeat is a simple server monitoring plugin for Hangfire.  It can easily be used to monitor CPU and RAM usage of the process that is running hangfire jobs, and optionally can monitor additional processes as well.
 
 Read about hangfire here: https://github.com/HangfireIO/Hangfire#hangfire-
 and here: http://hangfire.io/


### PR DESCRIPTION
I originally didn't use this project because I thought it was a process monitor for the server, which seems orthogonal to HangFire.  I realized much later on revisiting this page that it is monitoring the CPU and RAM of just the Hangfire process, which is super useful.  Updated readme to clarify.